### PR TITLE
Reverting short counts array back to int64

### DIFF
--- a/include/hdr/hdr_histogram.h
+++ b/include/hdr/hdr_histogram.h
@@ -14,7 +14,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define YB_USE_SHORT_COUNT_TYPE 1
 #define YB_FLEXIBLE_COUNTS_ARRAY 1
 
 #ifdef YB_USE_SHORT_COUNT_TYPE


### PR DESCRIPTION
We want to have histograms tracking more than uint32_max in each bucket, and we are willing to accommodate the increased memory consumption per histogram. This change brings the default counts array format back to the original int64 type reflected in mainline. 